### PR TITLE
Sophia MenuItemReviews - Added create page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReviews/MenuItemReviewEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -58,6 +62,21 @@ function App() {
             <>
               <Route exact path="/restaurants/edit/:id" element={<RestaurantEditPage />} />
               <Route exact path="/restaurants/create" element={<RestaurantCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/menuitemreviews" element={<MenuItemReviewIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/menuitemreviews/edit/:id" element={<MenuItemReviewEditPage />} />
+              <Route exact path="/menuitemreviews/create" element={<MenuItemReviewCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -93,7 +93,7 @@ function App() {
         {
             hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/menuitemreviews" element={<HelpRequestIndexPage />} />
+              <Route exact path="/menuitemreviews" element={<MenuItemReviewIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,6 +56,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
+                  <Nav.Link as={Link} to="/menuitemreviews">MenuItemReview</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
                 </>
               )

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
@@ -1,13 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage() {
+export default function MenuItemReviewCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
-}
+const objectToAxiosParams = (menuItemReview) => ({
+    url: "/api/menuitemreviews/post",
+    method: "POST",
+    params: {
+        itemId: menuItemReview.itemId,
+        reviewerEmail: menuItemReview.reviewerEmail,
+        stars: menuItemReview.stars,
+        dateReviewed: menuItemReview.dateReviewed,
+        comments: menuItemReview.comments
+    }
+    });
+
+  const onSuccess = (menuItemReview) => {
+    toast(`New review Created - id: ${menuItemReview.id} itemId: ${menuItemReview.itemId} stars: ${menuItemReview.stars}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/menuitemreviews/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreviews" />
+  }
+
+    // Stryker disable all : placeholder for future implementation
+    return (
+        <BasicLayout>
+        <div className="pt-2">
+            <h1>Create New MenuItemReview</h1>
+            <MenuItemReviewForm submitAction={onSubmit} />
+        </div>
+        </BasicLayout>
+    )
+    }

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.js
@@ -49,3 +49,5 @@ const objectToAxiosParams = (menuItemReview) => ({
         </BasicLayout>
     )
     }
+
+    

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/menuitemreviews/create">Create</a></p>
+        <p><a href="/menuitemreviews/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
@@ -28,4 +28,3 @@ Default.parameters = {
     ]
 }
 
-

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage"
+
+export default {
+    title: 'pages/MenuItemReviews/MenuItemReviewCreatePage',
+    component: MenuItemReviewCreatePage
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/menuitemreviews/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
@@ -124,4 +124,3 @@ describe("MenuItemReviewCreatePage tests", () => {
 
 });
 
-

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,6 +7,26 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("MenuItemReviewCreatePage tests", () => {
 
@@ -19,11 +39,10 @@ describe("MenuItemReviewCreatePage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
+    test("Renders without crashing", () => {
         // arrange
-
         setupUserOnly();
+        const queryClient = new QueryClient();
        
         // act
         render(
@@ -33,9 +52,74 @@ describe("MenuItemReviewCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+    });
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    test("on submit, makes request to backend, and redirects to /menuitemreviews", async () => {
+
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        const menuItemReview = {
+            id: 1,
+            itemId: 11,
+            reviewerEmail: "sophiattran@ucsb.edu",
+            stars: 2,
+            dateReviewed: "2022-01-03T00:00",
+            comments: "this kinda sucked"
+        };
+
+        axiosMock.onPost("/api/menuitemreviews/post").reply(202, menuItemReview);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Menu Item ID")).toBeInTheDocument();
+        });
+
+        const itemIdInput = screen.getByLabelText("Menu Item ID");
+        expect(itemIdInput).toBeInTheDocument();
+
+        const reviewerEmailInput = screen.getByLabelText("Email");
+        expect(reviewerEmailInput).toBeInTheDocument();
+
+        const starsInput = screen.getByLabelText("Stars");
+        expect(starsInput).toBeInTheDocument();
+
+        const dateReviewedInput = screen.getByLabelText("Date (iso format)");
+        expect(dateReviewedInput).toBeInTheDocument();
+
+        const commentsInput = screen.getByLabelText("Comments");
+        expect(commentsInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(itemIdInput, { target: { value: '11' } })
+        fireEvent.change(reviewerEmailInput, { target: { value: 'sophiattran@ucsb.edu' } })
+        fireEvent.change(starsInput, { target: { value: '2' } })
+        fireEvent.change(dateReviewedInput, { target: { value: '2022-01-03T00:00' } })
+        fireEvent.change(commentsInput, { target: { value: 'this kinda sucked' } })
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            itemId: "11",
+            reviewerEmail: "sophiattran@ucsb.edu",
+            stars: "2",
+            dateReviewed: "2022-01-03T00:00",
+            comments: "this kinda sucked"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New review Created - id: 1 itemId: 11 stars: 2");
+        expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreviews" });
+
     });
 
 });

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewEditPage from "main/pages/MenuItemReviews/MenuItemReviewEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("MenuItemReviewEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("MenuItemReviewIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+


### PR DESCRIPTION
In this PR, we added the Create page for MenuItemReviews and linked it to the API.

Closes #40 

Storybook: 
![image](https://github.com/ucsb-cs156-w24/team03-w24-5pm-3/assets/92010986/1f4142c3-d8dd-42f5-9a29-22dd8225e743)

Localhost (also tested that pressing "create" passes in the input on the Swagger UI): 
![image](https://github.com/ucsb-cs156-w24/team03-w24-5pm-3/assets/92010986/64038bc1-170a-448d-b3cc-49ba1624ee3b)
